### PR TITLE
Re-using specs from ad2-getting-started

### DIFF
--- a/spec/features/1_basic_spec.rb
+++ b/spec/features/1_basic_spec.rb
@@ -31,13 +31,6 @@ describe "The /movies/new page" do
       "Expected /movies/new to have a form with action='/movies'."
   end
 
-  it "has a hidden authenticity token input", points: 2 do
-    visit "/movies/new"
-
-    expect(page).to have_selector("input[name='authenticity_token']", visible: false),
-      "Expected the new movie form to have an input field of type='hidden' and name='authenticity_token'."
-  end
-
   it "creates a movie successfully", point: 1 do
     visit "/movies/new"
 

--- a/spec/features/1_basic_spec.rb
+++ b/spec/features/1_basic_spec.rb
@@ -1,0 +1,91 @@
+require "rails_helper"
+
+describe "The /movies page" do
+  before do
+    visit "/movies"
+  end
+
+  it "can be visited", points: 1 do
+    expect(page.status_code).to be(200),
+      "Expected to visit /movies successfully."
+  end
+
+  it "has a link to add a movie", points: 1 do
+    expect(page).to have_link('Add a new movie', href: "/movies/new"),
+      "Expected /movies to have an 'Add a new movie' link to '/movies/new'."
+  end
+end
+
+describe "The /movies/new page" do
+  before do
+    visit "/movies/new"
+  end
+
+  it "can be visited", points: 1 do
+    expect(page.status_code).to be(200),
+      "Expected to visit /movies/new successfully."
+  end
+
+  it "has a form", points: 1 do
+    expect(page).to have_selector("form[action='/movies']"),
+      "Expected /movies/new to have a form with action='/movies'."
+  end
+
+  it "has a hidden authenticity token input", points: 2 do
+    expect(page).to have_selector("input[name='authenticity_token']", visible: false),
+      "Expected the new movie form to have an input field of type='hidden' and name='authenticity_token'."
+  end
+
+  it "creates a movie successfully", point: 1 do
+    fill_in "Title", with: "My test movie"
+    fill_in "Description", with: "description"
+    click_button "Create Movie"
+    expect(page).to have_content("Movie created successfully."),
+      "Expected to fill in the new movie form, click 'Create Movie', and be redirected to the movie index with a success notice"
+  end
+end
+
+describe "The movie details page" do
+  before do
+    @movie = Movie.create(
+      title: "My title",
+      description: "My description"
+    )
+    visit "/movies/#{@movie.id}"
+  end
+
+  it "can be visited", points: 1 do
+    expect(page.status_code).to be(200),
+      "Expected to visit /movies/ID successfully."
+  end
+
+  it "has a link to delete the movie with a DELETE request", points: 2 do
+    expect(page).to have_selector("a[href='/movies/#{ @movie.id }'][data-method='delete']", text: 'Delete Movie'),
+      "Expected /movies/ID to have 'Delete Movie' link with the proper data-method='delete'."
+  end
+end
+
+describe "The movie edit page" do
+  before do
+    @movie = Movie.create(
+      title: "My title",
+      description: "My description"
+    )
+    visit "/movies/#{@movie.id}/edit"
+  end
+
+  it "can be visited", points: 1 do
+    expect(page.status_code).to be(200),
+      "Expected to visit /movies/ID/edit successfully."
+  end
+
+  it "has a form", points: 1 do
+    expect(page).to have_selector("form[action='/movies/#{@movie.id}'][method='post']"),
+      "Expected /movies/ID/edit to have a form with action='/movies/ID' and method='post'."
+  end
+
+  it "has a hidden patch input", points: 2 do
+    expect(page).to have_selector("input[name='_method'][value='patch']", visible: false),
+      "Expected the edit movie form to have an input field of type='hidden' with name='_method' and value='patch'."
+  end
+end

--- a/spec/features/1_basic_spec.rb
+++ b/spec/features/1_basic_spec.rb
@@ -1,90 +1,93 @@
 require "rails_helper"
 
 describe "The /movies page" do
-  before do
-    visit "/movies"
-  end
-
   it "can be visited", points: 1 do
+    visit "/movies"
+
     expect(page.status_code).to be(200),
       "Expected to visit /movies successfully."
   end
 
   it "has a link to add a movie", points: 1 do
+    visit "/movies"
+
     expect(page).to have_link('Add a new movie', href: "/movies/new"),
       "Expected /movies to have an 'Add a new movie' link to '/movies/new'."
   end
 end
 
 describe "The /movies/new page" do
-  before do
-    visit "/movies/new"
-  end
-
   it "can be visited", points: 1 do
+    visit "/movies/new"
+
     expect(page.status_code).to be(200),
       "Expected to visit /movies/new successfully."
   end
 
   it "has a form", points: 1 do
+    visit "/movies/new"
+
     expect(page).to have_selector("form[action='/movies']"),
       "Expected /movies/new to have a form with action='/movies'."
   end
 
   it "has a hidden authenticity token input", points: 2 do
+    visit "/movies/new"
+
     expect(page).to have_selector("input[name='authenticity_token']", visible: false),
       "Expected the new movie form to have an input field of type='hidden' and name='authenticity_token'."
   end
 
   it "creates a movie successfully", point: 1 do
+    visit "/movies/new"
+
     fill_in "Title", with: "My test movie"
     fill_in "Description", with: "description"
     click_button "Create Movie"
+
     expect(page).to have_content("Movie created successfully."),
       "Expected to fill in the new movie form, click 'Create Movie', and be redirected to the movie index with a success notice"
   end
 end
 
 describe "The movie details page" do
-  before do
-    @movie = Movie.create(
-      title: "My title",
-      description: "My description"
-    )
-    visit "/movies/#{@movie.id}"
-  end
+  let(:movie) { Movie.create(title: "My title", description: "My description") }
 
   it "can be visited", points: 1 do
+    visit "/movies/#{movie.id}"
+
     expect(page.status_code).to be(200),
       "Expected to visit /movies/ID successfully."
   end
 
   it "has a link to delete the movie with a DELETE request", points: 2 do
-    expect(page).to have_selector("a[href='/movies/#{ @movie.id }'][data-method='delete']", text: 'Delete Movie'),
+    visit "/movies/#{movie.id}"
+
+    expect(page).to have_selector("a[href='/movies/#{movie.id}'][data-method='delete']", text: 'Delete Movie'),
       "Expected /movies/ID to have 'Delete Movie' link with the proper data-method='delete'."
   end
 end
 
 describe "The movie edit page" do
-  before do
-    @movie = Movie.create(
-      title: "My title",
-      description: "My description"
-    )
-    visit "/movies/#{@movie.id}/edit"
-  end
+  let(:movie) { Movie.create(title: "My title", description: "My description") }
 
   it "can be visited", points: 1 do
+    visit "/movies/#{movie.id}/edit"
+
     expect(page.status_code).to be(200),
       "Expected to visit /movies/ID/edit successfully."
   end
 
   it "has a form", points: 1 do
-    expect(page).to have_selector("form[action='/movies/#{@movie.id}'][method='post']"),
+    visit "/movies/#{movie.id}/edit"
+
+    expect(page).to have_selector("form[action='/movies/#{movie.id}'][method='post']"),
       "Expected /movies/ID/edit to have a form with action='/movies/ID' and method='post'."
   end
 
   it "has a hidden patch input", points: 2 do
+    visit "/movies/#{movie.id}/edit"
+
     expect(page).to have_selector("input[name='_method'][value='patch']", visible: false),
       "Expected the edit movie form to have an input field of type='hidden' with name='_method' and value='patch'."
   end

--- a/spec/features/dummy_spec.rb
+++ b/spec/features/dummy_spec.rb
@@ -1,7 +1,0 @@
-require "rails_helper"
-
-describe "This project" do
-  it "has no tests" do
-    expect(1).to eq(1)
-  end
-end


### PR DESCRIPTION
This first helper methods project is just a re-factoring, so all of the tests pass and the goal is just to not "break" anything and have the tests keep passing in the end. 

A better way might be actually testing for the presence of the helper methods in the source code, rather than just testing the HTML output. But I'm not sure how/if we want to do that.

Things to potentially test for here (in the future off separate PRs):

- [ ] presence of `link_to`
- [ ] presence of `form_with` in `new.html.erb` and `edit.html.erb`
- [ ] presence of `find` in controller
- [ ] removal of `query_` from form params and change from strings to symbols
- [ ] presence of bundled sub-hashes in forms and mass assignment in controllers
- [ ] presence of `resources` in `routes.rb`