### PR TITLE
Advanced specs to test code

### DIFF
--- a/spec/helper_methods/2_helper_spec.rb
+++ b/spec/helper_methods/2_helper_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+describe "movies/index" do
+  it "uses an embedded Ruby link_to helper method", points: 2 do
+    template_name = "movies/index.html.erb"
+    template_path = Rails.root.join('app', 'views', template_name)
+    template_contents = open(template_path).read
+    expect(template_contents).to match /<%= link_to "Show details", movie %>/
+  end
+end

--- a/spec/helper_methods/2_helper_spec.rb
+++ b/spec/helper_methods/2_helper_spec.rb
@@ -3,9 +3,9 @@ require "rails_helper"
 describe "movies/index" do
   it "uses an embedded Ruby link_to helper method", points: 2 do
     template_name = "movies/index.html.erb"
-    template_path = Rails.root.join('app', 'views', template_name)
+    template_path = Rails.root.join("app", "views", template_name)
     template_contents = open(template_path).read
-    expect(template_contents).to match(/<%=.*link_to.*Show details.*%>/),
-      "Expected to find `link_to` method with text 'Show details' in movies/index.html.erb"
+    expect(template_contents).to match(/<%=.*link_to.*Add a new movie.*%>/),
+      "Expected to find `link_to` method with text 'Add a new movie' in movies/index.html.erb"
   end
 end

--- a/spec/helper_methods/2_helper_spec.rb
+++ b/spec/helper_methods/2_helper_spec.rb
@@ -5,6 +5,7 @@ describe "movies/index" do
     template_name = "movies/index.html.erb"
     template_path = Rails.root.join('app', 'views', template_name)
     template_contents = open(template_path).read
-    expect(template_contents).to match /<%= link_to "Show details", movie %>/
+    expect(template_contents).to match(/<%=.*link_to.*Show details.*%>/),
+      "Expected to find `link_to` method with text 'Show details' in movies/index.html.erb"
   end
 end


### PR DESCRIPTION
So far, the previously added specs just test basic functionality.

A better way might be actually testing for the presence of the helper methods in the source code, rather than just testing the HTML output.

Things to potentially test for here:

- [x] presence of `link_to`
- [ ] presence of `form_with` in `new.html.erb` and `edit.html.erb`
- [ ] presence of `find` in controller
- [ ] removal of `query_` from form params and change from strings to symbols
- [ ] presence of bundled sub-hashes in forms and mass assignment in controllers
- [ ] presence of `resources` in `routes.rb`

An unconventional suggestion from @jelaniwoods that works well (and has already been added as a commit here):

```ruby
require "rails_helper"

describe "movies/index" do
  it "uses an embedded Ruby link_to helper method", points: 2 do
    template_name = "movies/index.html.erb"
    template_path = Rails.root.join('app', 'views', template_name)
    template_contents = open(template_path).read
    expect(template_contents).to match /<%= link_to "Show details", movie %>/
  end
end
```